### PR TITLE
Correct cron in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 :scheduler:
   :schedule:
     hello_world:
-      cron: '0 * * * * *'   # Runs once per minute
+      cron: '0 * * * *'   # Runs once per minute
       class: HelloWorld
 ```
 


### PR DESCRIPTION
The current format of the cron difination is invalid As can be seen: [crontab](https://crontab.guru/#0_*_*_*_*_*)

Removing a * gives a valid syntax: [crontab](https://crontab.guru/#0_*_*_*_*)